### PR TITLE
feat(branch_config): deprecate dev_signin_redirect_url and add signin…

### DIFF
--- a/cdk_webapp_skeleton/auth_stack.py
+++ b/cdk_webapp_skeleton/auth_stack.py
@@ -39,14 +39,11 @@ class AuthStack(cdk.Stack):
         else:
             user_pool = self.find_user_pool()
 
-        development_signin_url = branch_config.dev_signin_redirect_url
-        production_signin_url = f"https://{branch_config.domain_name}/signin"
-
         frontend_pool_client = user_pool.add_client(
             "app-client",
             generate_secret=False,
             o_auth=cognito.OAuthSettings(
-                callback_urls=[development_signin_url, production_signin_url]
+                callback_urls=branch_config.signin_redirect_urls
             ),
             access_token_validity=cdk.Duration.days(1),
             refresh_token_validity=cdk.Duration.days(30),

--- a/cdk_webapp_skeleton/branch_config.py
+++ b/cdk_webapp_skeleton/branch_config.py
@@ -1,10 +1,13 @@
 import abc
+import warnings
 from abc import ABC
 from typing import Optional
 
 from aws_cdk import aws_route53 as route53
 from aws_cdk import pipelines as pipelines
 from constructs import Construct
+
+HTTP_LOCALHOST_SIGNIN = "http://localhost:3000/signin"
 
 
 class BranchConfig(ABC):
@@ -91,4 +94,13 @@ class BranchConfig(ABC):
     @property
     def dev_signin_redirect_url(self) -> Optional[str]:
         """URL to redirect to after signing in during development."""
-        return "http://localhost:3000/signin"
+        warnings.warn(
+            "dev_signin_redirect_url will be deprecated in favor of overriding signin_redirect_urls",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        return HTTP_LOCALHOST_SIGNIN
+
+    @property
+    def signin_redirect_urls(self) -> list[str]:
+        return [HTTP_LOCALHOST_SIGNIN, f"https://{self.domain_name}/signin"]


### PR DESCRIPTION
…_redirect_urls to allow for an arbitrary number of redirect URLs

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 8ea1114900ab85a160ffd2d64d9f39fde395c235  | 
|--------|

### Summary:
Deprecates `dev_signin_redirect_url` and introduces `signin_redirect_urls` for flexible authentication redirect handling in AWS CDK configured web app.

**Key points**:
- Deprecate `dev_signin_redirect_url` in `BranchConfig`.
- Introduce `signin_redirect_urls` supporting multiple URLs.
- Update `AuthStack` to use new `signin_redirect_urls`.
- Emit deprecation warning when using old property.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
