### PR TITLE
fix(react_website): add 'unsafe-inline' to script-src in CloudFront's…

### DIFF
--- a/cdk_webapp_skeleton/react_website.py
+++ b/cdk_webapp_skeleton/react_website.py
@@ -44,7 +44,7 @@ class ReactWebsite(Construct):
             security_headers_behavior=cloudfront.ResponseSecurityHeadersBehavior(
                 content_security_policy=cloudfront.ResponseHeadersContentSecurityPolicy(
                     content_security_policy="default-src 'self'; img-src 'self' https: data: ; "
-                    "script-src 'self' https: 'unsafe-eval'; "
+                    "script-src 'self' https: 'unsafe-eval' 'unsafe-inline'; "
                     "style-src 'self' 'unsafe-inline' https: ; font-src 'self' data:; "
                     f"object-src 'none'; connect-src 'self' *.{branch_config.domain_name} "
                     f"cognito-idp.us-east-1.amazonaws.com {branch_config.auth_domain_name}",


### PR DESCRIPTION
… CSP
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 9b5807f7fc60aaadc31234bb110de5ee5b05e5a2  | 
|--------|--------|

### Summary:
Added 'unsafe-inline' to the 'script-src' directive in the CSP of the React website to allow inline scripts.

**Key points**:
- **File Modified**: `cdk_webapp_skeleton/react_website.py`
- **Class Modified**: `ReactWebsite`
- **Change**: Added `'unsafe-inline'` to the `script-src` directive in the Content Security Policy (CSP).
- **Reason**: Allows inline scripts, which might be necessary for certain functionalities or third-party integrations.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->