### PR TITLE
ci(test): run tests on any push, but only upload build as artifact if…

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,6 +4,7 @@ on:
     secrets:
       CODECOV_TOKEN:
         required: true
+  push:
 
 jobs:
   install-and-test:
@@ -51,6 +52,7 @@ jobs:
       - name: Build package
         run: poetry build
       - name: 'Upload Build'
+        if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v3
         with:
           name: dist

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Build package
         run: poetry build
       - name: 'Upload Build'
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_call'
         uses: actions/upload-artifact@v3
         with:
           name: dist

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -39,7 +39,7 @@ jobs:
           path: .venv
           key: venv-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
-        if: steps.cached-venv.outputs.cache-hit != 'true'
+        # if: steps.cached-venv.outputs.cache-hit != 'true'
         run: poetry install --no-root
       - name: Run tests
         run: poetry run pytest


### PR DESCRIPTION
… running on the "main" branch
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit bf44fb53ce81586268fb81bfdd0b408f74fbfeae  | 
|--------|--------|

### Summary:
Run tests on any push but only upload build artifacts if on the `main` branch in `.github/workflows/ci-cd.yml`.

**Key points**:
- Modified `.github/workflows/ci-cd.yml` to run tests on any push.
- Added condition to `Upload Build` step to only upload artifacts if on `main` branch.
- Ensures builds are only stored for the `main` branch, optimizing storage.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->