### PR TITLE
fix(react_website): add 'blob:' to 'worker-src' in CloudFront's CSP t…

### DIFF
--- a/cdk_webapp_skeleton/react_website.py
+++ b/cdk_webapp_skeleton/react_website.py
@@ -47,7 +47,8 @@ class ReactWebsite(Construct):
                     "script-src 'self' https: 'unsafe-eval' 'unsafe-inline'; "
                     "style-src 'self' 'unsafe-inline' https: ; font-src 'self' data:; "
                     f"object-src 'none'; connect-src 'self' *.{branch_config.domain_name} "
-                    f"cognito-idp.us-east-1.amazonaws.com {branch_config.auth_domain_name} *.sentry.io",
+                    f"cognito-idp.us-east-1.amazonaws.com {branch_config.auth_domain_name} *.sentry.io; "
+                    "worker-src blob: ; ",
                     override=True,
                 )
             ),


### PR DESCRIPTION
…o enable Sentry
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f9c19d9737a64d73652720b4d12d4143fa13b9d7  | 
|--------|--------|

### Summary:
Added 'blob:' to 'worker-src' in CloudFront's CSP in `ReactWebsite` to enable Sentry.

**Key points**:
- Updated `cdk_webapp_skeleton/react_website.py`.
- Modified `ReactWebsite.__init__` to add `'blob:'` to `worker-src` in CloudFront's CSP.
- Ensures Sentry works correctly by allowing `blob:` sources for workers.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->